### PR TITLE
Make block placements remove ghost snitches

### DIFF
--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -166,6 +166,15 @@ public abstract class SnitchMod {
 		if (blockState == Blocks.AIR.defaultBlockState()) {
 			lastBrokenBlockPos = pos;
 			lastBrokenBlockTs = System.currentTimeMillis();
+		// Prevent interaction between this and placing new snitches.
+		} else if (!blockState.is(Blocks.JUKEBOX) && !blockState.is(Blocks.NOTE_BLOCK)) {
+			WorldPos potentialSnitchPos = new WorldPos(
+				store.server, getCurrentWorld(), pos.getX(), pos.getY(), pos.getZ());
+			if (store.getAllSnitches().contains(potentialSnitchPos)) {
+				// The player placed a block where we think a snitch is. That's
+				// impossible, so we need to remove the snitch.
+				store.deleteSnitch(potentialSnitchPos);
+			}
 		}
 	}
 


### PR DESCRIPTION
Use case:
 1. I place a snitch.
 2. Somebody else destroys it.
 3. The snitch outline is still there.
 4. There's nothing I can do about it.

This change fixes that - I can now place a block where the snitch was to clear the outline.

May not be the best idea:
 1. Snitch lookups are kinda slow (linear traversal of a generic collection) and we're doing it on every block placement.
 6. This issue could be solved by deleting snitches not present in /jalist.