### PR TITLE
Infer snitch field previews from snitch placements

### DIFF
--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/Renderer.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/Renderer.java
@@ -3,6 +3,7 @@ package gjum.minecraft.civ.snitchmod.common;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import gjum.minecraft.civ.snitchmod.common.model.Snitch;
+import gjum.minecraft.civ.snitchmod.common.model.SnitchFieldPreview;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.debug.DebugRenderer;
 import net.minecraft.network.chat.Component;
@@ -59,13 +60,13 @@ public class Renderer {
 		RenderSystem.applyModelViewMatrix();
 	}
 
-	private static void renderSnitchFieldPreview(Snitch snitch) {
+	private static void renderSnitchFieldPreview(SnitchFieldPreview preview) {
 		float boxAlpha = 0.2f;
 		float lineAlpha = 1;
 		float lineWidth = 2;
 		int blockHlDist = 64;
 
-		final AABB range = snitch.getRangeAABB();
+		final AABB range = preview.field().getRangeAABB();
 
 		// inflate/deflate so the box face isn't obscured by adjacent blocks
 		final boolean playerInRange = range.contains(mc.player.position());
@@ -84,11 +85,11 @@ public class Renderer {
 
 		renderBoxOutline(rangeBox, r, g, b, lineAlpha, lineWidth);
 
-		if (snitch.pos.distSqr(mc.player.blockPosition()) < blockHlDist * blockHlDist) {
+		if (preview.field().pos.distSqr(mc.player.blockPosition()) < blockHlDist * blockHlDist) {
 			RenderSystem.disableDepthTest();
 
 			// inflate so it isn't obstructed by the snitch block
-			final AABB blockBox = new AABB(snitch.pos).inflate(.01);
+			final AABB blockBox = new AABB(preview.field().pos).inflate(.01);
 			renderBoxOutline(blockBox, r, g, b, lineAlpha, lineWidth);
 		}
 	}

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -55,7 +55,7 @@ public abstract class SnitchMod {
 	public boolean rangeOverlayVisible = false;
 	public boolean placementHelperVisible = false;
 	@Nullable
-	public Snitch snitchFieldToPreview = null;
+	public SnitchFieldPreview snitchFieldToPreview = null;
 
 	@Nullable
 	private SnitchesStore store;
@@ -155,31 +155,16 @@ public abstract class SnitchMod {
 				break;
 			}
 			Snitch nearestSnitch = optNearestSnitch.get();
-			BlockPos previewPos = PlacementHelper.transposeSnitchFieldPositionByDirection(
-				nearestSnitch.getPos(),
-				mc.player.getYRot(),
-				mc.player.getXRot());
-			if (previewPos == null) {
-				// TODO log this
-				logToChat(new TextComponent("Internal error"));
-				break;
-			}
 
 			if (placementHelperVisible) {
 				placementHelperVisible = false;
 			}
 
-			Snitch newSnitchFieldToPreview = new Snitch(
-				new WorldPos(
-					nearestSnitch.getPos().getServer(),
-					nearestSnitch.getPos().getWorld(),
-					previewPos.getX(),
-					previewPos.getY(),
-					previewPos.getZ()));
-
+			SnitchFieldPreview newSnitchFieldToPreview = new SnitchFieldPreview(
+				nearestSnitch, Direction.ofPlayer(mc.player));
 			if (
 				snitchFieldToPreview != null
-				&& newSnitchFieldToPreview.getPos().equals(snitchFieldToPreview.getPos())
+				&& newSnitchFieldToPreview.equals(snitchFieldToPreview)
 			) {
 				logToChat(new TextComponent("Turning off the snitch field preview"));
 				snitchFieldToPreview = null;

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -199,6 +199,21 @@ public abstract class SnitchMod {
 		Snitch snitchCreated = SnitchCreatedChatParser.fromChat(message, store.server, getCurrentWorld(), getClientUuid());
 		if (snitchCreated != null) {
 			store.updateSnitchFromCreation(snitchCreated);
+
+			if (
+				snitchFieldToPreview != null
+				&& snitchFieldToPreview.field().pos.equals(snitchCreated.pos)
+			) {
+				if (placementHelperVisible) {
+					placementHelperVisible = false;
+				}
+
+				snitchFieldToPreview = new SnitchFieldPreview(
+					snitchCreated, snitchFieldToPreview.direction());
+
+				logToChat(new TextComponent("Showing an inferred snitch field preview"));
+			}
+
 			return false;
 		}
 

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Direction.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Direction.java
@@ -1,0 +1,25 @@
+package gjum.minecraft.civ.snitchmod.common.model;
+
+import net.minecraft.client.player.LocalPlayer;
+
+public class Direction {
+    private Yaw yaw;
+    private Pitch pitch;
+
+    public Direction(Yaw yaw, Pitch pitch) {
+        this.yaw = yaw;
+        this.pitch = pitch;
+    }
+
+    public static Direction ofPlayer(LocalPlayer p) {
+        return new Direction(Yaw.ofPlayer(p), Pitch.ofPlayer(p));
+    }
+
+    public Yaw yaw() {
+        return this.yaw;
+    }
+
+    public Pitch pitch() {
+        return this.pitch;
+    }
+}

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Pitch.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Pitch.java
@@ -1,0 +1,19 @@
+package gjum.minecraft.civ.snitchmod.common.model;
+
+import net.minecraft.client.player.LocalPlayer;
+
+public class Pitch {
+    private double value;
+
+    public Pitch(double pitch) {
+        this.value = pitch;
+    }
+
+    public static Pitch ofPlayer(LocalPlayer p) {
+        return new Pitch(p.getXRot());
+    }
+
+    public double value() {
+        return this.value;
+    }
+}

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/SnitchFieldPreview.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/SnitchFieldPreview.java
@@ -1,22 +1,47 @@
-package gjum.minecraft.civ.snitchmod.common;
+package gjum.minecraft.civ.snitchmod.common.model;
 
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class PlacementHelper {
-	public static @Nullable BlockPos transposeSnitchFieldPositionByDirection(
-			@NotNull
-			BlockPos fieldCenter,
-			double yaw,
-			double pitch) {
+public class SnitchFieldPreview {
+	private Snitch source;
+	private Direction direction;
+	private Snitch field;
+
+	public SnitchFieldPreview(
+		Snitch source,
+		Direction direction
+	) {
+		this.source = source;
+		this.direction = direction;
+
+		BlockPos previewPos = transposeSnitchFieldPositionByDirection(
+			source.getPos(),
+			direction);
+		this.field = new Snitch(
+			new WorldPos(
+				source.getPos().getServer(),
+				source.getPos().getWorld(),
+				previewPos.getX(),
+				previewPos.getY(),
+				previewPos.getZ()));
+	}
+
+	public static @NotNull BlockPos transposeSnitchFieldPositionByDirection(
+		@NotNull
+		BlockPos fieldCenter,
+		@NotNull
+		Direction direction
+	) {
 		int x = fieldCenter.getX();
 		int y = fieldCenter.getY();
 		int z = fieldCenter.getZ();
+		double yaw = direction.yaw().value();
 		yaw = ((double) yaw + 180) % 360;
 		if (yaw < 0) {
 			yaw += 360;
 		}
+		double pitch = direction.pitch().value();
 
 		// Straight up
 		if (pitch <= -60) {
@@ -73,6 +98,29 @@ public class PlacementHelper {
 			return new BlockPos(x-22, y, z-22);
 		}
 
-		return null;
+		throw new IllegalArgumentException(String.format(
+			"Out of range values of yaw %f and/or pitch %f.",
+			direction.yaw().value(), direction.pitch().value()));
+	}
+
+	public Snitch source() {
+		return this.source;
+	}
+
+	public Direction direction() {
+		return this.direction;
+	}
+
+	public Snitch field() {
+		return this.field;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof SnitchFieldPreview)) {
+			return false;
+		}
+		SnitchFieldPreview p = (SnitchFieldPreview)obj;
+		return this.field.pos.equals(p.field.pos);
 	}
 }

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Yaw.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/model/Yaw.java
@@ -1,0 +1,19 @@
+package gjum.minecraft.civ.snitchmod.common.model;
+
+import net.minecraft.client.player.LocalPlayer;
+
+public class Yaw {
+    private double value;
+
+    public Yaw(double yaw) {
+        this.value = yaw;
+    }
+
+    public static Yaw ofPlayer(LocalPlayer p) {
+        return new Yaw(p.getYRot());
+    }
+
+    public double value() {
+        return this.value;
+    }
+}


### PR DESCRIPTION
Behavior:
> If a snitch preview is already shown and we place a new snitch directly where the previewed snitch is, a new preview gets created based off the new snitch in the same direction as the last one.

Makes creating snitch lines far more convenient.

---

Code wise it's good enough I hope. 
 1. The codebase's inconsistent in regard to getters/setters. `Snitch` has a public `.pos` but also a `getPos()`, etc. I chose to use getters, just to ensure immutability, but without the redundant `get` prefix.
 2. `Yaw`&`Pitch` may be overkill to define, but it's mostly Java's fault for being so incredibly verbose. In a normal language, they could just be one-line definitions in a single file, e.g. `type Pitch double; type Yaw double;` 🤷🏽 