### PR TITLE
Automatically name replaced snitches

### DIFF
--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -222,7 +222,13 @@ public abstract class SnitchMod {
 				&& !lastBrokenSnitch.getName().equals("")
 				&& lastBrokenSnitch.pos.equals(snitchCreated.pos)
 			) {
-				mc.player.chat(String.format("/janame %s ", lastBrokenSnitch.getName()));
+				mc.player.chat(
+					String.format(
+						"/janameat %d %d %d %s",
+						lastBrokenSnitch.pos.getX(),
+						lastBrokenSnitch.pos.getY(),
+						lastBrokenSnitch.pos.getZ(),
+						lastBrokenSnitch.getName()));
 				logToChat(new TextComponent("Named the replaced snitch"));
 			}
 

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -56,6 +56,8 @@ public abstract class SnitchMod {
 	public boolean placementHelperVisible = false;
 	@Nullable
 	public SnitchFieldPreview snitchFieldToPreview = null;
+	@Nullable
+	public Snitch lastBrokenSnitch = null;
 
 	@Nullable
 	private SnitchesStore store;
@@ -214,6 +216,16 @@ public abstract class SnitchMod {
 				logToChat(new TextComponent("Showing an inferred snitch field preview"));
 			}
 
+			if (
+				lastBrokenSnitch != null
+				&& lastBrokenSnitch.getName() != null
+				&& !lastBrokenSnitch.getName().equals("")
+				&& lastBrokenSnitch.pos.equals(snitchCreated.pos)
+			) {
+				mc.player.chat(String.format("/janame %s ", lastBrokenSnitch.getName()));
+				logToChat(new TextComponent("Named the replaced snitch"));
+			}
+
 			return false;
 		}
 
@@ -222,6 +234,12 @@ public abstract class SnitchMod {
 			SnitchBroken snitchBroken = SnitchBroken.fromChat(message, lastBrokenBlockPos, store.server, getCurrentWorld());
 			if (snitchBroken != null) {
 				store.updateSnitchBroken(snitchBroken);
+
+				Snitch snitch = store.getSnitch(getCurrentWorld(), lastBrokenBlockPos);
+				if (snitch != null) {
+					lastBrokenSnitch = snitch;
+				}
+
 				return false;
 			}
 		}
@@ -243,7 +261,14 @@ public abstract class SnitchMod {
 				&& !blockState.is(Blocks.JUKEBOX)
 				&& !blockState.is(Blocks.NOTE_BLOCK)
 		) {
-			store.updateSnitchGone(new WorldPos(store.server, getCurrentWorld(), pos));
+			WorldPos worldPos = new WorldPos(store.server, getCurrentWorld(), pos);
+
+			store.updateSnitchGone(worldPos);
+
+			Snitch snitch = store.getSnitch(worldPos);
+			if (snitch != null) {
+				lastBrokenSnitch = snitch;
+			}
 		}
 	}
 


### PR DESCRIPTION
**Current behavior:** Replacing a snitch clears its name.

**New behavior:** Replacing a snitch is followed by an automatic `/janame`, using the name the snitch had before.

Especially useful for gone snitches, since replacing them is common and having to rename manually is annoying. Doubly so since the current behavior irreversibly gets rid of the old name once a new snitch gets placed.

# Code

It's a little awkward to fetch a snitch from storage like this just for the database-updating function to do its own fetch immediately after.
 