### PR TITLE
Fix excessive polling in the snitch-saving thread

### DIFF
--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchesStore.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchesStore.java
@@ -43,11 +43,16 @@ public class SnitchesStore {
 					List<Snitch> snitches = new ArrayList<>(lastAddedSnitchCount);
 					while (true) {
 						Snitch newSnitch = queuedDBSnitches.poll();
+
 						if (newSnitch != null) {
 							snitches.add(newSnitch);
 						}
 
-						if (newSnitch == null || snitches.size() >= 1000 || System.currentTimeMillis() - startTime >= 1000) {
+						if (
+							newSnitch == null
+							|| snitches.size() >= 1000
+							|| System.currentTimeMillis() - startTime >= 1000
+						) {
 							if (db != null) db.upsertSnitches(snitches);
 							lastAddedSnitchCount = snitches.size();
 							break;

--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchesStore.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchesStore.java
@@ -47,7 +47,7 @@ public class SnitchesStore {
 							snitches.add(newSnitch);
 						}
 
-						if (snitches.size() >= 1000 || System.currentTimeMillis() - startTime >= 1000) {
+						if (newSnitch == null || snitches.size() >= 1000 || System.currentTimeMillis() - startTime >= 1000) {
 							if (db != null) db.upsertSnitches(snitches);
 							lastAddedSnitchCount = snitches.size();
 							break;


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Gjum/SnitchMod/pull/39

# The bug
The outer `while` loop calls the inner one every second. The inner one then spends the entire next second continuously polling the snitch queue whether there are any snitches in it or not. In other words, the code alternates between doing nothing for 1s and busy looping for 1s.

# The fix
The fixed inner loop exits as soon as its polling of the snitch queue results in no snitch being returned. For example, in the most common case of no snitches being in the queue at all, the loop exits immediately without doing any real work, then the outer loop goes to sleep for 1s again.

---

There doesn't seem to be any difference in real-world FPS either way 🤷🏽‍♀️ 