### PR TITLE
Forge/Neo fixes

### DIFF
--- a/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
+++ b/common/src/main/java/gjum/minecraft/civ/snitchmod/common/SnitchMod.java
@@ -11,13 +11,13 @@ import gjum.minecraft.civ.snitchmod.common.model.SnitchFieldPreview;
 import gjum.minecraft.civ.snitchmod.common.model.SnitchRename;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Matrix4f;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 public abstract class SnitchMod {
-	private final static Minecraft mc = Minecraft.getInstance();
+	protected static Minecraft mc = Minecraft.getInstance();
 	public static final KeyMapping.Category SNITCHMOD_CATEGORY
 		= KeyMapping.Category.register(Identifier.fromNamespaceAndPath("snitchmod", "category"));
 
@@ -243,6 +243,20 @@ public abstract class SnitchMod {
 			logToChat(Component.literal("Showing a snitch field preview in the direction you're looking"));
 		}
 		// TODO if block pos changed -> if pos inside snitch range not in before -> send jainfo -> mark refreshed
+		// Check for J key press while in JAList GUI
+		var mc = Minecraft.getInstance();
+		if (mc.screen instanceof AbstractContainerScreen<?> containerScreen) {
+			String title = containerScreen.getTitle().getString();
+			if ((title.toLowerCase().contains("snitches") || title.contains("JukeAlert"))
+					&& GLFW.glfwGetKey(mc.getWindow().handle(), GLFW.GLFW_KEY_J) == GLFW.GLFW_PRESS) {
+
+				// Prevent spam clicking by checking if auto-paginator is not already active
+				if (!JalistAutoPaginator.getInstance().isActive()) {
+					System.out.println("[SnitchMod] J key detected in JAList!");
+					JalistAutoPaginator.getInstance().startAutoPagination();
+				}
+			}
+		}
 	}
 
 	/**

--- a/fabric/src/main/java/gjum/minecraft/civ/snitchmod/fabric/FabricSnitchMod.java
+++ b/fabric/src/main/java/gjum/minecraft/civ/snitchmod/fabric/FabricSnitchMod.java
@@ -1,15 +1,10 @@
 package gjum.minecraft.civ.snitchmod.fabric;
 
-import gjum.minecraft.civ.snitchmod.common.JalistAutoPaginator;
 import gjum.minecraft.civ.snitchmod.common.SnitchMod;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
-import org.lwjgl.glfw.GLFW;
 
 public class FabricSnitchMod extends SnitchMod implements ClientModInitializer {
 	@Override
@@ -21,34 +16,15 @@ public class FabricSnitchMod extends SnitchMod implements ClientModInitializer {
 		KeyBindingHelper.registerKeyBinding(toggleSnitchGoneStatusKey);
 		KeyBindingHelper.registerKeyBinding(jalistAutoKey);
 
-		ClientTickEvents.START_CLIENT_TICK.register(client -> {
-			try {
-				handleTick();
-				
-				// Check for J key press while in JAList GUI
-				var mc = Minecraft.getInstance();
-				if (mc.screen instanceof AbstractContainerScreen<?> containerScreen) {
-					String title = containerScreen.getTitle().getString();
-					if ((title.toLowerCase().contains("snitches") || title.contains("JukeAlert")) 
-						&& GLFW.glfwGetKey(mc.getWindow().handle(), GLFW.GLFW_KEY_J) == GLFW.GLFW_PRESS) {
-						
-						// Prevent spam clicking by checking if auto-paginator is not already active
-						if (!JalistAutoPaginator.getInstance().isActive()) {
-							System.out.println("[FabricSnitchMod] J key detected in JAList!");
-							JalistAutoPaginator.getInstance().startAutoPagination();
-						}
-					}
-				}
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		});
-		WorldRenderEvents.END_MAIN.register(((context) -> {
-			try {
-				handleRenderBlockOverlay(context.matrices());
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}));
-	}
+        ClientTickEvents.START_CLIENT_TICK.register(client -> {
+            handleTick();
+        });
+        WorldRenderEvents.END_MAIN.register(((context) -> {
+            try {
+                handleRenderBlockOverlay(context.matrices());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }));
+    }
 }

--- a/forge/src/main/java/gjum/minecraft/civ/snitchmod/forge/ForgeSnitchMod.java
+++ b/forge/src/main/java/gjum/minecraft/civ/snitchmod/forge/ForgeSnitchMod.java
@@ -1,11 +1,13 @@
 package gjum.minecraft.civ.snitchmod.forge;
 
 import gjum.minecraft.civ.snitchmod.common.SnitchMod;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("snitchmod")
@@ -21,10 +23,16 @@ public class ForgeSnitchMod extends SnitchMod {
         event.register(togglePlacementKey);
         event.register(previewSnitchFieldKey);
         event.register(toggleSnitchGoneStatusKey);
+        event.register(jalistAutoKey);
     }
 
 	@SubscribeEvent
 	public void onClientTick(TickEvent.ClientTickEvent.Pre event) {
 		handleTick();
 	}
+
+    @SubscribeEvent
+    public void onClientLoaded(FMLClientSetupEvent event) {
+        mc = Minecraft.getInstance();
+    }
 }

--- a/forge/src/main/java/gjum/minecraft/civ/snitchmod/forge/mixins/LevelRenderMixin.java
+++ b/forge/src/main/java/gjum/minecraft/civ/snitchmod/forge/mixins/LevelRenderMixin.java
@@ -1,9 +1,15 @@
 package gjum.minecraft.civ.snitchmod.forge.mixins;
 
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
 import com.mojang.blaze3d.vertex.PoseStack;
 import gjum.minecraft.civ.snitchmod.forge.ForgeSnitchMod;
+import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import org.joml.Matrix4f;
+import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,10 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelRenderer.class)
 public abstract class LevelRenderMixin { // REMINDER: Forge sucks
-    /*@Inject(method = "renderSectionLayer", at = @At("RETURN"))
-    private void onRenderLevelLast(RenderType arg, double d, double e, double f, Matrix4f matrix4f, Matrix4f matrix4f2, CallbackInfo ci) {
-        if (arg == RenderType.translucent()) {
-            ForgeSnitchMod.getMod().handleRenderBlockOverlay(new PoseStack().last().pose());
-        }
-    }*/
+
+    @Inject(method = "method_62214", at = @At(value = "INVOKE:LAST", target = "Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;endBatch()V"))
+    private void onRenderLevelLast(CallbackInfo ci) {
+        ForgeSnitchMod.getMod().handleRenderBlockOverlay(new PoseStack());
+    }
 }

--- a/neoforge/src/main/java/gjum/minecraft/civ/snitchmod/neoforge/NeoForgeSnitchMod.java
+++ b/neoforge/src/main/java/gjum/minecraft/civ/snitchmod/neoforge/NeoForgeSnitchMod.java
@@ -1,13 +1,18 @@
 package gjum.minecraft.civ.snitchmod.neoforge;
 
+import gjum.minecraft.civ.snitchmod.common.JalistAutoPaginator;
 import gjum.minecraft.civ.snitchmod.common.SnitchMod;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.event.lifecycle.ClientStartedEvent;
 import net.neoforged.neoforge.common.NeoForge;
+import org.lwjgl.glfw.GLFW;
 
 @Mod("snitchmod")
 public class NeoForgeSnitchMod extends SnitchMod {
@@ -22,6 +27,7 @@ public class NeoForgeSnitchMod extends SnitchMod {
         event.register(togglePlacementKey);
         event.register(previewSnitchFieldKey);
         event.register(toggleSnitchGoneStatusKey);
+        event.register(jalistAutoKey);
     }
 
     @SubscribeEvent
@@ -32,5 +38,24 @@ public class NeoForgeSnitchMod extends SnitchMod {
     @SubscribeEvent
     public void onClientTick(ClientTickEvent.Pre event) {
         handleTick();
+
+        var mc = Minecraft.getInstance();
+        if (mc.screen instanceof AbstractContainerScreen<?> containerScreen) {
+            String title = containerScreen.getTitle().getString();
+            if ((title.toLowerCase().contains("snitches") || title.contains("JukeAlert"))
+                    && GLFW.glfwGetKey(mc.getWindow().handle(), GLFW.GLFW_KEY_J) == GLFW.GLFW_PRESS) {
+
+                // Prevent spam clicking by checking if auto-paginator is not already active
+                if (!JalistAutoPaginator.getInstance().isActive()) {
+                    System.out.println("[FabricSnitchMod] J key detected in JAList!");
+                    JalistAutoPaginator.getInstance().startAutoPagination();
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onClientLoaded(ClientStartedEvent event) {
+        mc = Minecraft.getInstance();
     }
 }


### PR DESCRIPTION
Moves the jalist auto function to handleTick, registers the Jalist auto keybind on both Forge and Neoforge. Fixes a crash on Neoforge when doing anything as the Minecraft.getInstance() call is done too early and is null. Reenables Forge rendering with the correct mixin. Apologies for not noticing that Neo and Forge were broken with my previous PRs. 